### PR TITLE
adding unit tests for ris2bib

### DIFF
--- a/test/ris2bib_test.go
+++ b/test/ris2bib_test.go
@@ -1,0 +1,23 @@
+package ris2bib
+
+
+import (  
+	"github.com/harrisonlabollita/ris-2-bib"
+    "testing"
+)
+
+func TestCreateBib(t *testing.T){
+
+    var filename string = "test.ris"
+
+    data, err := os.ReadFile(filename);
+    if err != nil { log.Fatal(err) }
+
+    bib_ref := bib_entry{ " ",
+                          " ",
+                          {" ", " ", " "},
+
+    }
+
+
+}

--- a/test/test.ris
+++ b/test/test.ris
@@ -1,0 +1,15 @@
+TY  - JOUR
+AU  - Doe,   J.
+AU  - Smith, L.
+AU  - Jones, R.
+PY  - 2022
+DA  - 2022/01/01
+TI  - This is a title that will be parsed
+JO  - NoWhere
+SP  - 200
+EP  - 100
+VL  - 100
+IS  - 1000
+AB  - A test ris file that absolutely means nothing and has no meaning at all. This abstract absolutely has no meaning or contain any substantial content.
+SN  - 1476-4687
+UR  - https://github.com/harrisonlabollita/ris-2-bib


### PR DESCRIPTION
This PR is the start of setting up unit tests for keeping consistency of ris2bib. Addresses issue #6 